### PR TITLE
Add Pydantic models for search and fetch results in sample_mcp.py

### DIFF
--- a/sample_mcp.py
+++ b/sample_mcp.py
@@ -1,21 +1,38 @@
 import json
 from pathlib import Path
 from fastmcp.server import FastMCP
+from pydantic import BaseModel
 
 RECORDS = json.loads(Path(__file__).with_name("records.json").read_text())
 LOOKUP = {r["id"]: r for r in RECORDS}
 
+class SearchResult(BaseModel):
+    id: str
+    title: str
+    text: str
+
+class SearchResultPage(BaseModel):
+    results: list[SearchResult]
+
+class FetchResult(BaseModel):
+    id: str
+    title: str
+    text: str
+    url: str | None = None
+    metadata: dict[str, str] | None = None
 
 def create_server():
     mcp = FastMCP(name="Cupcake MCP", instructions="Search cupcake orders")
 
     @mcp.tool()
-    async def search(query: str):
+    async def search(query: str) -> SearchResultPage:
         """
         Search for cupcake orders – keyword match.
+
+        Returns a SearchResultPage containing a list of SearchResult items.
         """
         toks = query.lower().split()
-        ids = []
+        results: list[SearchResult] = []
         for r in RECORDS:
             hay = " ".join(
                 [
@@ -25,17 +42,31 @@ def create_server():
                 ]
             ).lower()
             if any(t in hay for t in toks):
-                ids.append(r["id"])
-        return {"ids": ids}
+                results.append(
+                    SearchResult(id=r["id"], title=r.get("title", ""), text=r.get("text", ""))
+                )
+
+        # Return the Pydantic model (FastMCP will serialise it for us)
+        return SearchResultPage(results=results)
 
     @mcp.tool()
-    async def fetch(id: str):
+    async def fetch(id: str) -> FetchResult:
         """
         Fetch a cupcake order by ID.
+
+        Returns a FetchResult model.
         """
         if id not in LOOKUP:
             raise ValueError("unknown id")
-        return LOOKUP[id]
+
+        r = LOOKUP[id]
+        return FetchResult(
+            id=r["id"],
+            title=r.get("title", ""),
+            text=r.get("text", ""),
+            url=r.get("url"),
+            metadata=r.get("metadata"),
+        )
 
     return mcp
 


### PR DESCRIPTION
Updated to change how data is returned, noticed that DR connector is prone to hallucinate with current implementation as data isn't being returned from /search

Changing to pydantic baseobjects fixes this issue